### PR TITLE
Fix users-manual chap.2.1.1

### DIFF
--- a/doc/users-manual/running.xml
+++ b/doc/users-manual/running.xml
@@ -60,16 +60,18 @@ items.
       <para>You can obtain the full description of the command line options
       giving -h option to <command>ecell3-em2eml</command>.</para>
       <para>
-      <screen>ecell3-eml2em -- convert eml to em
-         
+        <screen>ecell3-em2eml -- convert a EM file to a EML file
+
 Usage:
-        ecell3-eml2em [-h] [-f] [-o outfile] infile
- 
-         
+        ecell3-em2eml [-h] [-o EMLFILE] [-p PATCHFILE] infile.em
+        By default this command automatically overwrite EMLFILE.
+
 Options:
-        -h or --help    :  Print this message.
-        -f or --force   :  Force overwrite even if outfile already exists.
-        -o or --outfile=:  Specify output file name.  '-' means stdout.
+        -h or --help            : Print this message.
+        -o or --outfile=EMLFILE : Specify the output file name. '-' means stdout.
+        -p or --patch=PATCHFILE : Read PATCHFILE, override parameters by the input
+                                  and then produce EMLFILE.
+        -E or --preprocess      : Preprocessing only. Implies -o -.
 </screen>
       </para>
     </sect2>


### PR DESCRIPTION
This chapter explains the function of 'ecell3-em2eml' command,
but code example showed the result of 'ecell3-eml2em'.

This commit fixes this bug.
