### PR TITLE
Fix EntityStub.exists()

### DIFF
--- a/ecell/pyecell/ecell/EntityStub.py
+++ b/ecell/pyecell/ecell/EntityStub.py
@@ -87,7 +87,7 @@ class EntityStub( ObjectStub ):
         return -> exist:TRUE / not exist:FALSE
         This method can throw exceptions.
         """
-        return self.theSimulator().isEntityExist( self.theFullIDString )
+        return self.theSimulator().entityExists( self.theFullIDString )
 
     def setProperty( self, aPropertyName, aValue ):
         """


### PR DESCRIPTION
Correcting C++ API method name.
Ref: This API defined in SRCROOT/ecell/libemc/Simulator.hpp

Sample code:
  ecell3-session>>> loadModel('model.eml')
  <model.eml, t=0>>> s = createEntityStub('Variable:/:S')
  <model.eml, t=0>>> s.exists() # formerly failed
